### PR TITLE
Set X-Forwarded-For header for backend requests

### DIFF
--- a/src/middleware/proxy.js
+++ b/src/middleware/proxy.js
@@ -31,6 +31,7 @@ module.exports = function backendProxyMiddleware(config, eventHandler) {
             host = backend.host || targetHost,
             backendHeaders = {
               'x-forwarded-host': req.headers.host || 'no-forwarded-host',
+              'x-forwarded-for': req.headers['x-forwarded-for'] || remoteAddress,
               host: host,
               'x-tracer': req.tracer
             },


### PR DESCRIPTION
Compoxure should probably set X-Forwarded-For for backend requests as that's standard proxy behaviour.