### PR TITLE
Configurable status code log level

### DIFF
--- a/src/middleware/proxy.js
+++ b/src/middleware/proxy.js
@@ -36,6 +36,7 @@ module.exports = function backendProxyMiddleware(config, eventHandler) {
             targetCacheKey = backend.cacheKey || utils.urlToCacheKey(targetUrl),
             targetCacheTTL = utils.timeToMillis(backend.ttl || '30s'),
             explicitNoCache = backend.noCache || req.explicitNoCache,
+            statusCodeLogLevel = backend.statusCodeLogLevel || {},
             options;
 
         if (config.cdn && config.cdn.url) { backendHeaders['x-cdn-url'] = config.cdn.url; }
@@ -71,10 +72,11 @@ module.exports = function backendProxyMiddleware(config, eventHandler) {
         };
 
         var logError = function(err, message) {
-           var logLevel = err.statusCode === 404 ? 'warn' : 'error';
-           eventHandler.logger(logLevel, message, {
-              tracer: req.tracer
-           });
+          var logLevel = statusCodeLogLevel[err.statusCode] || 'error';
+
+          eventHandler.logger(logLevel, message, {
+            tracer: req.tracer
+          });
         }
 
         var handleError = function(err, oldCacheData) {

--- a/test/common/test404.html
+++ b/test/common/test404.html
@@ -1,6 +1,6 @@
 <html>
     <body>
-        <div cx-url='{{server:local}}/404' cx-cache-key='404' cx-cache-ttl='5s' cx-timeout='500' class='block'>
+        <div cx-url='{{server:local}}/404' cx-cache-key='404' cx-status-code-log-level="404:warn" cx-cache-ttl='5s' cx-timeout='500' class='block'>
             This fragment will return a 404
         </div>
     </body>

--- a/test/common/testConfig.json
+++ b/test/common/testConfig.json
@@ -16,7 +16,10 @@
      "backend": [
         {
             "pattern":"/404backend",
-            "target":"http://localhost:5001/404backend"
+            "target":"http://localhost:5001/404backend",
+            "statusCodeLogLevel": {
+                "404": "warn"
+            }
         },
         {
             "pattern":"/alternate500",


### PR DESCRIPTION
- Added cx-status-code-log-level as a cx attribute for html PC html fragments with format 403:warn,404:info
- Added statusCodeLogLevel property to backend configs as an object with status code as keys and log level as value
- Tested using console.log statements because there is no trivial way to test our logs statements atm
