### PR TITLE
tes/resources#1186 pass along the correct Host: header. The way we ha…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "compoxure",
-  "version": "0.3.45",
+  "version": "0.3.46",
   "description": "Composition proxy middleware for Express, allows for composition of microservices using declarations and caching.",
   "main": "index.js",
   "scripts": {

--- a/src/middleware/proxy.js
+++ b/src/middleware/proxy.js
@@ -29,7 +29,7 @@ module.exports = function backendProxyMiddleware(config, eventHandler) {
             targetHost = url.parse(backend.target).hostname,
             host = backend.host || targetHost,
             backendHeaders = {
-              'x-forwarded-host': req.headers.host || 'no-forwarded-host',
+              'x-forwarded-host': req.headers['x-forwarded-host'] || req.headers.host || 'no-forwarded-host',
               'x-forwarded-for': req.headers['x-forwarded-for'] || remoteAddress,
               host: host,
               'x-tracer': req.tracer


### PR DESCRIPTION
…ve nginx set up, it rewrites Host: to be something like app-resource.service.staging.tescloud.com

https://github.com/tes/resources/issues/1186