### PR TITLE
Simple addition of experiment properties to variables so they can be used in any cx-directive

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ module.exports = function(config, eventHandler, optionsTransformer) {
   eventHandler.logger = eventHandler.logger || function() {};
   eventHandler.stats = eventHandler.stats || function() {};
 
-  optionsTransformer = optionsTransformer || function(options, next) { next(null, options); };
+  optionsTransformer = optionsTransformer || function(req, options, next) { next(null, options); };
 
   var backendProxyMiddleware = require('./src/middleware/proxy')(config, eventHandler, optionsTransformer);
   var cacheMiddleware = require('reliable-get/CacheMiddleware')(config);

--- a/index.js
+++ b/index.js
@@ -1,13 +1,15 @@
 var cookieParser = require('cookie-parser');
 var ware = require('ware');
 
-module.exports = function(config, eventHandler) {
+module.exports = function(config, eventHandler, optionsTransformer) {
 
   eventHandler = eventHandler || {};
   eventHandler.logger = eventHandler.logger || function() {};
   eventHandler.stats = eventHandler.stats || function() {};
 
-  var backendProxyMiddleware = require('./src/middleware/proxy')(config, eventHandler);
+  optionsTransformer = optionsTransformer || function(options, next) { next(null, options); };
+
+  var backendProxyMiddleware = require('./src/middleware/proxy')(config, eventHandler, optionsTransformer);
   var cacheMiddleware = require('reliable-get/CacheMiddleware')(config);
   var selectBackend = require('./src/middleware/backend')(config);
   var rejectUnsupportedMediaType = require('./src/middleware/mediatypes');

--- a/src/middleware/htmlparser.js
+++ b/src/middleware/htmlparser.js
@@ -142,6 +142,7 @@ function getMiddleware(config, reliableGet, eventHandler, optionsTransformer) {
             };
 
             optionsTransformer(req, options, function(err, transformedOptions) {
+                if (err) { return onErrorHandler(err, {}, transformedOptions); }
                 reliableGet.get(transformedOptions, function(err, response) {
                     if(err) {
                         return onErrorHandler(err, response, transformedOptions);

--- a/src/middleware/proxy.js
+++ b/src/middleware/proxy.js
@@ -109,6 +109,7 @@ module.exports = function backendProxyMiddleware(config, eventHandler, optionsTr
         }
 
         optionsTransformer(req, options, function(err, transformedOptions) {
+          if (err) { return handleError(err); }
           reliableGet.get(transformedOptions, function(err, response) {
             if(err) {
               handleError(err, response);

--- a/src/middleware/proxy.js
+++ b/src/middleware/proxy.js
@@ -4,10 +4,10 @@ var HttpStatus = require('http-status-codes');
 var ReliableGet = require('reliable-get');
 var url = require('url');
 
-module.exports = function backendProxyMiddleware(config, eventHandler) {
+module.exports = function backendProxyMiddleware(config, eventHandler, optionsTransformer) {
 
     var reliableGet = new ReliableGet(config),
-        htmlParserMiddleware = HtmlParserProxy.getMiddleware(config, reliableGet, eventHandler);
+        htmlParserMiddleware = HtmlParserProxy.getMiddleware(config, reliableGet, eventHandler, optionsTransformer);
 
     reliableGet.on('log', eventHandler.logger);
     reliableGet.on('stat', eventHandler.stats);
@@ -108,16 +108,18 @@ module.exports = function backendProxyMiddleware(config, eventHandler) {
           }
         }
 
-        reliableGet.get(options, function(err, response) {
-          if(err) {
-            handleError(err, response);
-          } else {
-            req.templateVars = utils.updateTemplateVariables(req.templateVars, response.headers);
-            if(response.headers['set-cookie']) {
-              res.setHeader('set-cookie', response.headers['set-cookie']);
+        optionsTransformer(req, options, function(err, transformedOptions) {
+          reliableGet.get(transformedOptions, function(err, response) {
+            if(err) {
+              handleError(err, response);
+            } else {
+              req.templateVars = utils.updateTemplateVariables(req.templateVars, response.headers);
+              if(response.headers['set-cookie']) {
+                res.setHeader('set-cookie', response.headers['set-cookie']);
+              }
+              res.parse(response.content);
             }
-            res.parse(response.content);
-          }
+          });
         });
 
       });

--- a/src/parameters/RequestInterrogator.js
+++ b/src/parameters/RequestInterrogator.js
@@ -34,7 +34,7 @@ module.exports = function (config, cdn, environment) {
             server: config.servers,
             env: environment,
             user: user,
-            experiment: req.experiment || {},
+            experiments: req.experiments || {},
             device: {type: deviceType}
         };
 

--- a/src/parameters/RequestInterrogator.js
+++ b/src/parameters/RequestInterrogator.js
@@ -34,6 +34,7 @@ module.exports = function (config, cdn, environment) {
             server: config.servers,
             env: environment,
             user: user,
+            experiment: req.experiment || {},
             device: {type: deviceType}
         };
 

--- a/test/acceptance/compoxure.test.js
+++ b/test/acceptance/compoxure.test.js
@@ -186,10 +186,17 @@ describe("Page Composer", function(){
         });
     });
 
-     it('should use the experiment variables if they are available', function(done) {
+    it('should use the experiment variables if they are available', function(done) {
         request.get(getPageComposerUrl(), {headers: {'accept': 'text/html'}}, function(err, response, content) {
             var $ = cheerio.load(content);
             expect($('#experiment').text()).to.be.equal('A123');
+            done();
+        });
+    });
+
+    it('should use the options transformer if provided', function(done) {
+        request.get(getPageComposerUrl('/transformer'), {headers: {'accept': 'text/html'}}, function(err, response, content) {
+            expect(content).to.be.equal('prefix-cache-key-suffix');
             done();
         });
     });

--- a/test/acceptance/compoxure.test.js
+++ b/test/acceptance/compoxure.test.js
@@ -186,6 +186,14 @@ describe("Page Composer", function(){
         });
     });
 
+     it('should use the experiment variables if they are available', function(done) {
+        request.get(getPageComposerUrl(), {headers: {'accept': 'text/html'}}, function(err, response, content) {
+            var $ = cheerio.load(content);
+            expect($('#experiment').text()).to.be.equal('A123');
+            done();
+        });
+    });
+
     it('should ignore a cx-url that is invalid', function(done) {
         getSection('', '', '#invalidurl', function(text) {
             expect(text).to.be.equal('Error: Service invalid FAILED due to Invalid URL invalid');

--- a/test/common/pageComposerTest.html
+++ b/test/common/pageComposerTest.html
@@ -40,5 +40,8 @@
         <div id='replace-outer'>wrapping <div id='replace-outer-content' cx-replace-outer='true' cx-url='{{server:local}}/replaced'></div> content</div>
          <div id='testlogic' cx-test='{{#query:logic}}Logic ftw!{{/query:logic}}'></div>
          <div id='environment' cx-test='{{env:name}}'></div>
+         <div id='experiment' cx-url='{{server:local}}/experiment?variant={{experiment:details_block}}' cx-cache-key="{{experiment:details_block}}" cx-timeout='10s' class='block'>
+            Experiment block
+        </div>
     </body>
 </html>

--- a/test/common/pageComposerTest.html
+++ b/test/common/pageComposerTest.html
@@ -40,7 +40,7 @@
         <div id='replace-outer'>wrapping <div id='replace-outer-content' cx-replace-outer='true' cx-url='{{server:local}}/replaced'></div> content</div>
          <div id='testlogic' cx-test='{{#query:logic}}Logic ftw!{{/query:logic}}'></div>
          <div id='environment' cx-test='{{env:name}}'></div>
-         <div id='experiment' cx-url='{{server:local}}/experiment?variant={{experiment:details_block}}' cx-cache-key="{{experiment:details_block}}" cx-timeout='10s' class='block'>
+         <div id='experiment' cx-url='{{server:local}}/experiment?variant={{experiments:details_block}}' cx-cache-key="{{experiments:details_block}}" cx-timeout='10s' class='block'>
             Experiment block
         </div>
     </body>

--- a/test/common/pcServer.js
+++ b/test/common/pcServer.js
@@ -24,7 +24,19 @@ function initPcServer(port, hostname, eventHandler, configFile) {
     }
     config.environment = 'test';
 
-    var compoxureMiddleware = cx(config, eventHandler);
+    // Example options transformer
+    var optionsTransformer = function(req, options, next) {
+        // You have full access to req, and the selected backend
+        if(req.backend && req.backend.name === 'transformer') {
+            // You can modify any element of the options object
+            options.cacheKey = 'prefix-' + options.cacheKey + '-suffix';
+            // Url modified to allow for testing
+            options.url = options.url + '?cacheKey=' + options.cacheKey;
+        }
+        next(null, options);
+    }
+
+    var compoxureMiddleware = cx(config, eventHandler, optionsTransformer);
 
     var server = express();
 

--- a/test/common/pcServer.js
+++ b/test/common/pcServer.js
@@ -29,6 +29,13 @@ function initPcServer(port, hostname, eventHandler, configFile) {
     var server = express();
 
     server.use(cookieParser());
+    server.use(function(req, res, next) {
+        // This would be a call off to a service (e.g. planout based)
+        // To retrieve active experiments for the current user.
+        // Assumed it returns a simple object one level of properties deep
+        req.experiment = {details_block: 'A123', another_test: 'B112'};
+        next();
+    });
     server.use(compoxureMiddleware);
 
     return function(next) {

--- a/test/common/pcServer.js
+++ b/test/common/pcServer.js
@@ -33,7 +33,7 @@ function initPcServer(port, hostname, eventHandler, configFile) {
         // This would be a call off to a service (e.g. planout based)
         // To retrieve active experiments for the current user.
         // Assumed it returns a simple object one level of properties deep
-        req.experiment = {details_block: 'A123', another_test: 'B112'};
+        req.experiments = {details_block: 'A123', another_test: 'B112'};
         next();
     });
     server.use(compoxureMiddleware);

--- a/test/common/stubServer.js
+++ b/test/common/stubServer.js
@@ -26,6 +26,11 @@ function initStubServer(fileName, port, hostname) {
         res.end(uuid.v1());
     });
 
+    app.get('/experiment', function(req, res) {
+        res.writeHead(200, {"Content-Type": "text/html"});
+        res.end(req.query.variant);
+    });
+
     app.get('/user/:user?', function(req, res) {
         res.writeHead(200, {"Content-Type": "text/html"});
         res.end("User: " + req.params.user || 'Unknown user');

--- a/test/common/stubServer.js
+++ b/test/common/stubServer.js
@@ -31,6 +31,11 @@ function initStubServer(fileName, port, hostname) {
         res.end(req.query.variant);
     });
 
+    app.get('/transformer', function(req, res) {
+        res.writeHead(200, {"Content-Type": "text/html"});
+        res.end(req.query.cacheKey);
+    });
+
     app.get('/user/:user?', function(req, res) {
         res.writeHead(200, {"Content-Type": "text/html"});
         res.end("User: " + req.params.user || 'Unknown user');

--- a/test/common/testConfig.json
+++ b/test/common/testConfig.json
@@ -75,6 +75,13 @@
             "target":"{{server:local}}"
         },
         {
+            "name":"transformer",
+            "pattern":"/transformer",
+            "dontPassUrl": false,
+            "cacheKey":"cache-key",
+            "target":"{{server:local}}"
+        },
+        {
             "pattern":".*",
             "target":"http://localhost:5001",
             "dontPassUrl": false

--- a/test/unit/RequestInterrogator.test.js
+++ b/test/unit/RequestInterrogator.test.js
@@ -328,7 +328,7 @@ describe('RequestInterrogator', function() {
             headers: {
                 host: 'localhost:5000'
             },
-            experiment: {
+            experiments: {
                 test: 'A'
             },
             method: 'GET',
@@ -340,7 +340,7 @@ describe('RequestInterrogator', function() {
 
         interrogator.interrogateRequest(req, function(params) {
             var expectedPageUrl = 'http://localhost:5000/teaching-resource/Queen-Elizabeth-II-Diamond-jubilee-2012-6206420';
-            expect(params).to.have.property('experiment:test', 'A');
+            expect(params).to.have.property('experiments:test', 'A');
             done();
         });
     });

--- a/test/unit/RequestInterrogator.test.js
+++ b/test/unit/RequestInterrogator.test.js
@@ -322,4 +322,27 @@ describe('RequestInterrogator', function() {
             done();
         });
     });
+
+    it('should pass experiment variables through so they can be used', function(done) {
+        var req  = httpMocks.createRequest({
+            headers: {
+                host: 'localhost:5000'
+            },
+            experiment: {
+                test: 'A'
+            },
+            method: 'GET',
+            url: '/teaching-resource/Queen-Elizabeth-II-Diamond-jubilee-2012-6206420'
+        });
+        req.connection = {};
+
+        var interrogator = new RequestInterrogator(config.parameters, config.cdn || {}, {name: 'test'});
+
+        interrogator.interrogateRequest(req, function(params) {
+            var expectedPageUrl = 'http://localhost:5000/teaching-resource/Queen-Elizabeth-II-Diamond-jubilee-2012-6206420';
+            expect(params).to.have.property('experiment:test', 'A');
+            done();
+        });
+    });
+
 });


### PR DESCRIPTION
This feels like a simpler and more idiomatic approach to experiments in PC?  

We still go get the experiments in PC (via the middleware), attach it to the request object.

Compoxure makes the experiment config available to be used in any ```{{experiment:details_block}}``` directive template, so it can explicitly be added to the backends or fragments that vary based on a given experiment.

Does this work?