### PR TITLE
tes/resources#2783 emit 'cache-control: no-cache, no-store, must-reva…

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,7 +382,7 @@ If any of the requests to a backend service via cx-url return a 404, then compox
 
 ## Cache-Control header on Responses from Microservices
 
-If a request to a backend service via cx-url returns a response with Cache-Control header set to no-store, this directive takes priority over any otherwise configured caching and response doesn't get cached. Compoxure also copies this header onto the response to the client. This is in efect a form of cache busting from microservice.
+If a request to a backend service via cx-url returns a response with Cache-Control header set to no-store or no-cache, this directive takes priority over any otherwise configured caching and response doesn't get cached. Compoxure also copies this header onto the response to the client; however, transforming it into `no-cache, no-store, must-revalidate`. This is in efect a form of cache busting from microservice.
 
 If a microservice responds with Cache-Control header with a max-age value, then this value takes priority over other caching config and response is cached for max-age time. Header is not copied to client response in this case
 

--- a/README.md
+++ b/README.md
@@ -382,7 +382,7 @@ If any of the requests to a backend service via cx-url return a 404, then compox
 
 ## Cache-Control header on Responses from Microservices
 
-If a request to a backend service via cx-url returns a response with Cache-Control header set to no-store or no-cache, this directive takes priority over any otherwise configured caching and response doesn't get cached. Compoxure also copies this header onto the response to the client; however, transforming it into `no-cache, no-store, must-revalidate`. This is in efect a form of cache busting from microservice.
+If a request to a backend service via cx-url returns a response with Cache-Control header set to no-store or no-cache, this directive takes priority over any otherwise configured caching and response doesn't get cached. Compoxure also copies this header onto the response to the client as `no-cache, no-store, must-revalidate`. This is in efect a form of cache busting from microservice.
 
 If a microservice responds with Cache-Control header with a max-age value, then this value takes priority over other caching config and response is cached for max-age time. Header is not copied to client response in this case
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "compoxure",
-  "version": "0.3.81",
+  "version": "0.3.82",
   "description": "Composition proxy middleware for Express, allows for composition of microservices using declarations and caching.",
   "main": "index.js",
   "scripts": {

--- a/src/middleware/htmlparser.js
+++ b/src/middleware/htmlparser.js
@@ -68,7 +68,7 @@ function getMiddleware(config, reliableGet, eventHandler, optionsTransformer) {
                     return (headers['cache-control'] || '').indexOf(value) !== -1;
                 }
                 if (hasCacheControl(headers, 'no-cache') || hasCacheControl(headers, 'no-store')) {
-                    res.setHeader('cache-control', 'no-store');
+                    res.setHeader('cache-control', 'no-cache, no-store, must-revalidate');
                 }
                 if (headers['set-cookie']) {
                   var existingResponseCookies = res.getHeader('set-cookie') || [];

--- a/test/acceptance/compoxure.test.js
+++ b/test/acceptance/compoxure.test.js
@@ -125,10 +125,10 @@ describe("Page Composer", function(){
         });
     });
 
-    it('should add no-store cache-control header if any fragments use cx-no-cache', function(done) {
+    it('should add no-cache, no-store, must-revalidate cache-control header if any fragments use cx-no-cache', function(done) {
         var requestUrl = getPageComposerUrl('noCacheBackend');
         request.get(requestUrl,{headers: {'accept': 'text/html'}}, function(err, response) {
-            expect(response.headers['cache-control']).to.be.equal('no-store');
+            expect(response.headers['cache-control']).to.be.equal('no-cache, no-store, must-revalidate');
             done();
         });
     });
@@ -262,9 +262,9 @@ describe("Page Composer", function(){
         });
     });
 
-    it('should pass no-store in Cache-control header from fragment response to client response', function(done) {
+    it('should pass no-cache, no-store, must-revalidate in Cache-control header from fragment response to client response', function(done) {
         request.get(getPageComposerUrl(), function(err, response) {
-            expect(response.headers['cache-control']).to.be.equal('no-store');
+            expect(response.headers['cache-control']).to.be.equal('no-cache, no-store, must-revalidate');
             done();
         });
     });


### PR DESCRIPTION
…lidate' instead of just no-store for responses that should not be cached
tes/resources#2783