### PR TITLE
Update state timeout for fragment if state is passed

### DIFF
--- a/src/middleware/htmlparser.js
+++ b/src/middleware/htmlparser.js
@@ -22,7 +22,7 @@ function getMiddleware(config, reliableGet, eventHandler, optionsTransformer) {
     var templateVars = req.templateVars;
     var fragmentTimings = [];
 
-    function getCx(fragment, next) {
+    function getCx(fragment, next, state) {
 
       /*jslint evil: true */
       var options,
@@ -64,6 +64,10 @@ function getMiddleware(config, reliableGet, eventHandler, optionsTransformer) {
         headers: optionsHeaders,
         tracer: req.tracer,
         statsdKey: statsdKey
+      }
+
+      if (state) {
+          state.allowTimeout(options.timeout);
       }
 
       var setResponseHeaders = function (headers) {


### PR DESCRIPTION
This, together with https://github.com/tes/parxer/pull/11, closes #71. It sets a fragment's timeout when handling a timeout, instead of using the backend timeout for every fragment.