### PR TITLE
Use response of the error handler as fragment content

### DIFF
--- a/src/middleware/htmlparser.js
+++ b/src/middleware/htmlparser.js
@@ -180,7 +180,9 @@ function getMiddleware(config, reliableGet, eventHandler, optionsTransformer) {
           var content;
           if (err) {
             content = onErrorHandler(err, response, transformedOptions);
-            responseCallback(null, content);
+            if ('string' === typeof content) {
+                responseCallback(null, content);
+            }
           } else {
             fragmentTimings.push({ url: options.url, status: response.statusCode, timing: response.timing });
             content = isDebugEnabled() ? delimitContent(response, options) : response.content;

--- a/src/middleware/htmlparser.js
+++ b/src/middleware/htmlparser.js
@@ -179,11 +179,13 @@ function getMiddleware(config, reliableGet, eventHandler, optionsTransformer) {
         reliableGet.get(transformedOptions, function (err, response) {
           var content;
           if (err) {
-            return onErrorHandler(err, response, transformedOptions);
+            content = onErrorHandler(err, response, transformedOptions);
+            responseCallback(null, content);
+          } else {
+            fragmentTimings.push({ url: options.url, status: response.statusCode, timing: response.timing });
+            content = isDebugEnabled() ? delimitContent(response, options) : response.content;
+            responseCallback(null, content, response.headers);
           }
-          fragmentTimings.push({ url: options.url, status: response.statusCode, timing: response.timing });
-          content = isDebugEnabled() ? delimitContent(response, options) : response.content;
-          responseCallback(null, content, response.headers);
         });
       });
 


### PR DESCRIPTION
This closes #66 

I'm experiencing lots of timeout problems with some microservices due to the services building up some kind of cache at some requests. This allows me to implement a statusCodeHandler which can detect a timeout and deal with, for example putting in some instruction to load the fragment later using XHR.

Example usage (not suitable for production ;)):

``` json
statusCodeHandlers":{
        "500":{
            "fn":"handleInternalServerError"
        }
    }
```

``` javascript
config.functions = {
    'handleInternalServerError': function(req, res, templateVars, data, transformedOptions, err) {
        if (err.message.match(/ETIMEDOUT$/)) {
            return '<script>document.location.reload();</script>';
        }
    }
};
```