### PR TITLE
Added missing response callback in proxy error handler

### DIFF
--- a/src/middleware/proxy.js
+++ b/src/middleware/proxy.js
@@ -97,7 +97,7 @@ module.exports = function backendProxyMiddleware(config, eventHandler, optionsTr
           var handlerDefn = config.statusCodeHandlers[err.statusCode];
           var handlerFn = config.functions && config.functions[handlerDefn.fn];
           if (handlerFn) {
-            return handlerFn(req, res, req.templateVars, handlerDefn.data, options, err);
+            return handlerFn(req, res, req.templateVars, handlerDefn.data, options, err, res.parse);
           }
         }
 


### PR DESCRIPTION
This was missing in #77 

Resulting in crashes when responseCallback is used when the backend times out.