### PR TITLE
Pass parserTimeout to parxer

### DIFF
--- a/src/middleware/htmlparser.js
+++ b/src/middleware/htmlparser.js
@@ -30,6 +30,7 @@ function getMiddleware(config, reliableGet, eventHandler, optionsTransformer) {
         minified: config.minified,
         showErrors: !req.backend.quietFailure,
         timeout: utils.timeToMillis(req.backend.timeout || '5000'),
+        parserTimeout: utils.timeToMillis(req.backend.parserTimeout || '5000'),
         plugins: [
           parxerPlugins.Test,
           parxerPlugins.If,


### PR DESCRIPTION
Completes fix in https://github.com/tes/parxer/pull/12 for #71 
