### PR TITLE
Adding docker-compose as a more easy way to start the example

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+
+FROM mhart/alpine-node
+WORKDIR /app
+EXPOSE 5000
+EXPOSE 5001
+ADD package.json package.json
+RUN \ 
+npm install --silent --progress=false && \
+rm -rf /root/.npm /root/.node-gyp

--- a/README.md
+++ b/README.md
@@ -10,8 +10,7 @@ For rationale (e.g. why the heck would anyone build this), please see the ration
 ```bash
 git clone git@github.com:tes/compoxure.git
 cd compoxure
-npm install
-node example
+docker-compose up
 ```
 Visit [http://localhost:5000/](http://localhost:5000/)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+version: '2'
+
+services:
+  redis:
+    image: redis:alpine
+    restart: always
+    ports:
+    - "6379:6379"
+  compoxure:
+    build: .
+    restart: always
+    environment:
+    - NODE_ENV=development
+    depends_on:
+    - redis
+    ports:
+    - "5000:5000"
+    - "5001:5001"
+    volumes:
+    - .:/app
+    - /app/node_modules
+    command: 'node example/index.js'

--- a/example/backend.js
+++ b/example/backend.js
@@ -90,6 +90,6 @@ server.use(connectRoute(function (router) {
 
 }));
 
-server.listen(5001, 'localhost', function () {
+server.listen(5001, function () {
   console.log('Example backend server on http://localhost:5001');
 });

--- a/example/config.json
+++ b/example/config.json
@@ -49,11 +49,11 @@
         "errorThreshold": 20,
         "volumeThreshold": 5,
         "includePath":true,
-        "publishToRedis":"redis://localhost:6379?db=0"
+        "publishToRedis":"redis://redis:6379?db=0"
     },
     "cache": {
         "engine": "redis",
-        "url":"redis://localhost:6379?db=0",
+        "url":"redis://redis:6379?db=0",
         "apiEnabled": true
     },
     "hogan": {

--- a/example/proxy.js
+++ b/example/proxy.js
@@ -46,7 +46,7 @@ server.use(query());
 if (process.env.logging !== 'false') { server.use(morgan('combined')); }
 server.use(compoxureMiddleware);
 
-server.listen(5000, 'localhost', function () {
+server.listen(5000, function () {
   console.log('Example compoxure server on http://localhost:5000');
 });
 


### PR DESCRIPTION
As the example needs redis to run, I've created a docker-compose file that will take care of building up the env for the example.
Maybe in the future we can build real microservices that would simulate the real life situation where you do call different servers. Let me know if you are interested in simulating something like this