### PR TITLE
adding parse me attribute

### DIFF
--- a/src/middleware/htmlparser.js
+++ b/src/middleware/htmlparser.js
@@ -10,6 +10,10 @@ var errorTemplate = _.template('<div style="color: red; font-weight: bold; font-
 var debugScriptTag = _.template('<script type="cx-debug-<%- type %>" data-cx-<%- type %>-id="<%- id %>"><%= data && JSON.stringify(data) %></script>');
 var debugScript = '<script>' + fs.readFileSync(path.join(__dirname, '../debug-script.js'), 'utf8') + '</script>';
 
+function hasCxAttr(node, name) {
+  return name in node.attribs || ('data-' + name in node.attribs);
+}
+
 function getCxAttr(node, name, defaultAttr) {
   var value = node.attribs[name] || node.attribs['data-' + name];
 
@@ -143,6 +147,7 @@ function getMiddleware(config, reliableGet, eventHandler, optionsTransformer) {
     function getParxerOpts(depth) {
       function getCx(fragment, next) {
         var start = Date.now();
+        var parseMeTag = hasCxAttr(fragment, 'cx-parse-me');
         var url = getCxAttr(fragment, 'cx-url');
         var cacheKeyAttr = getCxAttr(fragment, 'cx-cache-key');
         var ignoreError = getCxAttr(fragment, 'cx-ignore-error');
@@ -162,7 +167,7 @@ function getMiddleware(config, reliableGet, eventHandler, optionsTransformer) {
             return next(err, content, headers);
           }
 
-          if (!headers || !headers['cx-parse-me']) {
+          if (!parseMeTag && (!headers || !headers['cx-parse-me'])) {
             return next(err, content, headers);
           }
 

--- a/test/acceptance/compoxure.test.js
+++ b/test/acceptance/compoxure.test.js
@@ -685,8 +685,21 @@ describe("Page Composer", function () {
     });
   });
 
-  it('should allow & parse an additional fragment', function (done) {
+  it('should allow & parse an additional fragment (cx-parse-me header)', function (done) {
     var requestUrl = getPageComposerUrl('nested-fragment');
+    request.get(requestUrl, { headers: { 'accept': 'text/html' } }, function (err, response, content) {
+      expect(response.statusCode).to.be(200);
+      var $ = cheerio.load(response.body);
+      var expectedHTML = '<div><h1>Welcome</h1><p>Welcome content</p></div>';
+      expect(response.body).to.be(expectedHTML);
+      expect($('h1').text()).to.be('Welcome');
+      expect($('p').text()).to.be('Welcome content');
+      done();
+    });
+  });
+
+  it('should allow & parse an additional fragment (cx-parse-me tag)', function (done) {
+    var requestUrl = getPageComposerUrl('nested-fragment-2');
     request.get(requestUrl, { headers: { 'accept': 'text/html' } }, function (err, response, content) {
       expect(response.statusCode).to.be(200);
       var $ = cheerio.load(response.body);

--- a/test/common/stubServer.js
+++ b/test/common/stubServer.js
@@ -342,8 +342,18 @@ function initStubServer(fileName, port/*, hostname*/) {
     res.end('<div cx-url="{{server:local}}/welcome-fragment" cx-replace-outer="true"></div>');
   });
 
+  app.get('/nested-fragment-2', function (req, res) {
+    res.writeHead(200, { "Content-Type": "text/html" });
+    res.end('<div cx-parse-me cx-url="{{server:local}}/welcome-fragment-2" cx-replace-outer="true"></div>');
+  });
+
   app.get('/welcome-fragment', function (req, res) {
     res.writeHead(200, { "Content-Type": "text/html", "cx-parse-me": true });
+    res.end('<div><h1>Welcome</h1><div cx-url="{{server:local}}/fragment-content" cx-replace-outer="true"></div></div>');
+  });
+
+  app.get('/welcome-fragment-2', function (req, res) {
+    res.writeHead(200, { "Content-Type": "text/html" });
     res.end('<div><h1>Welcome</h1><div cx-url="{{server:local}}/fragment-content" cx-replace-outer="true"></div></div>');
   });
 


### PR DESCRIPTION
This covers the same feature as the cx-parse-me header, but it can be used for cx-library and cx-bundle.
Use case: replace urls in CSS with the cdn-url