### PR TITLE
Append sane cache-control headers if content not cacheable

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,9 @@ The configuration object looks as follows:
         "delimiters":"{{ }}"
     },
     "cache": {
+        "defaultNoCacheHeaders": {
+          "cache-control": "private, no-cache, max-age=0, must-revalidate, no-store"
+        },
         "engine": "redis"
     },
     "followRedirect": false,
@@ -161,6 +164,7 @@ To disable caching simply delete the entire config section.
 
 |Property|Description|
 ---------|------------
+defaultNoCacheHeaders|Headers to automatically append to any response that is not cached (optional)
 engine|The engine to use (currently only 'redis' is valid).
 url|If Redis, set a url for the redis server - e.g. localhost:6379?db=0
 host|If Redis, set the host explicitly (this and params below are an alternative to using url)
@@ -169,6 +173,7 @@ db|If Redis, set the db explicitly
 options|If redis, any option described at https://github.com/NodeRedis/node_redis#options-object-properties (e.g. to allow authentication)
 compress|Use snappy compression for caching
 namespace|Optional prefix for redis keys
+
 
 #### CDN Configuration
 

--- a/example/config.json
+++ b/example/config.json
@@ -44,6 +44,9 @@
         }
     },
     "cache": {
+        "defaultNoCacheHeaders": {
+            "cache-control": "private, no-cache, max-age=0, must-revalidate, no-store"
+        },
         "engine": "memory",
         "apiEnabled": true
     },

--- a/src/middleware/backend.js
+++ b/src/middleware/backend.js
@@ -55,6 +55,10 @@ module.exports = function (config) {
       });
     } else {
       req.backend = _.defaults(_.clone(req.backend), headerBackend, backendDefaults);
+      var backendNoCache = !req.backend.cacheKey || req.backend.noCache;
+      if (backendNoCache && config.cache.defaultNoCacheHeaders) {
+        req.backend.addResponseHeaders = _.defaults(req.backend.addResponseHeaders, config.cache.defaultNoCacheHeaders);
+      }
       req.backend.target = utils.render(req.backend.target, req.templateVars);
       req.backend.cacheKey = req.backend.cacheKey ? utils.render(req.backend.cacheKey, req.templateVars) : null;
       return next();

--- a/src/middleware/htmlparser.js
+++ b/src/middleware/htmlparser.js
@@ -125,7 +125,8 @@ function getMiddleware(config, reliableGet, eventHandler, optionsTransformer) {
         // it does not have no-cache or no-store.
         var backendCacheControl = res.getHeader('cache-control');
         if (!backendCacheControl || (backendCacheControl.indexOf('no-cache') === -1 && backendCacheControl.indexOf('no-store') === -1)) {
-          res.setHeader('cache-control', 'no-cache, no-store, must-revalidate');
+          var defaultCacheControl = config.cache.defaultNoCacheHeaders && config.cache.defaultNoCacheHeaders['cache-control'];
+          res.setHeader('cache-control', defaultCacheControl || 'private, no-cache, max-age=0, must-revalidate, no-store');
         }
       }
 

--- a/test/acceptance/compoxure.test.js
+++ b/test/acceptance/compoxure.test.js
@@ -149,7 +149,7 @@ describe("Page Composer", function () {
     });
   });
 
-  it('should pass through cache-control header', function (done) {
+  it('should pass through cache-control header from service if sent', function (done) {
     var requestUrl = getPageComposerUrl('noCacheBackend');
     request.get(requestUrl, { headers: { 'accept': 'text/html' } }, function (err, response) {
       expect(response.headers['cache-control']).to.be.equal('no-cache, no-store, must-revalidate, private, max-stale=0, post-check=0, pre-check=0');
@@ -157,10 +157,18 @@ describe("Page Composer", function () {
     });
   });
 
+  it('should default cache-control header', function (done) {
+    var requestUrl = getPageComposerUrl('noCacheBackendNoHeader');
+    request.get(requestUrl, { headers: { 'accept': 'text/html' } }, function (err, response) {
+      expect(response.headers['cache-control']).to.be.equal('private, no-cache, max-age=0, must-revalidate, no-store');
+      done();
+    });
+  });
+
   it('should use fragment\'s cache-control header overriding backend', function (done) {
     var requestUrl = getPageComposerUrl('noCacheBackendViaFragment');
     request.get(requestUrl, { headers: { 'accept': 'text/html' } }, function (err, response) {
-      expect(response.headers['cache-control']).to.be.equal('no-cache, no-store, must-revalidate');
+      expect(response.headers['cache-control']).to.be.equal('private, no-cache, max-age=0, must-revalidate, no-store');
       done();
     });
   });
@@ -295,8 +303,8 @@ describe("Page Composer", function () {
   });
 
   it('should pass no-cache, no-store, must-revalidate in Cache-control header from fragment response to client response', function (done) {
-    request.get(getPageComposerUrl(), function (err, response) {
-      expect(response.headers['cache-control']).to.be.equal('no-cache, no-store, must-revalidate');
+    request.get(getPageComposerUrl('/noCacheBackendViaFragment'), function (err, response) {
+      expect(response.headers['cache-control']).to.be.equal('private, no-cache, max-age=0, must-revalidate, no-store');
       done();
     });
   });

--- a/test/common/stubServer.js
+++ b/test/common/stubServer.js
@@ -211,6 +211,14 @@ function initStubServer(fileName, port/*, hostname*/) {
     res.end(backendHtml);
   });
 
+  app.get('/noCacheBackendNoHeader', function (req, res) {
+    res.writeHead(200, {
+      "Content-Type": "text/html",
+    });
+    var backendHtml = fs.readFileSync('./test/common/noCacheBackendFromFragment.html', { encoding: 'utf8' });
+    res.end(backendHtml);
+  });
+
   app.get('/noCacheBackendViaFragment', function (req, res) {
     res.writeHead(200, { "Content-Type": "text/html", "Cache-Control": 'private' });
     var backendHtml = fs.readFileSync('./test/common/noCacheBackendFromFragment.html', { encoding: 'utf8' });

--- a/test/common/testConfig.json
+++ b/test/common/testConfig.json
@@ -131,9 +131,16 @@
       "pattern": "/noCacheBackendViaFragment",
       "target": "{{server:local}}",
       "dontPassUrl": false,
+      "cacheKey": "noCacheBackendViaFragment",
       "passThroughHeaders": [
         "cache-control"
       ]
+    },
+    {
+      "name": "noCacheBackendNoHeader",
+      "pattern": "/noCacheBackendNoHeader",
+      "dontPassUrl": false,
+      "target": "{{server:local}}"
     },
     {
       "name": "noCacheBackend",
@@ -202,6 +209,9 @@
     }
   },
   "cache": {
+    "defaultNoCacheHeaders": {
+      "cache-control": "private, no-cache, max-age=0, must-revalidate, no-store"
+    },
     "engine": "memorycache"
   },
   "followRedirect": false,


### PR DESCRIPTION
As discussed re. ensuring logged in pages are never cached.

- If a backend is noCache
- OR If a backend has no cacheKey
- OR If a _fragment_ responds with cache-control headers that say it shouldn't be cached
- AND If the backend doesn't _already_ have default cache-control headers in addResponseHeaders (so you can specify something different for a specific backend if you like)
 
It will append them automatically to the response.  It is configured in the `cache` key in the config so you can change what it is.

```
"cache": {
    "defaultNoCacheHeaders": {
       "cache-control": "private, no-cache, max-age=0, must-revalidate, no-store"
    },
    "engine": "memorycache"
},
```