### PR TITLE
Include localisation headers

### DIFF
--- a/src/middleware/htmlparser.js
+++ b/src/middleware/htmlparser.js
@@ -250,7 +250,9 @@ function getMiddleware(config, reliableGet, eventHandler, optionsTransformer) {
             'cx-page-url': templateVars['url:href'],
             'x-tracer': req.tracer,
             'x-cdn-host': getCdnHost(),
-            'x-cdn-url': getCdnUrl()
+            'x-cdn-url': getCdnUrl(),
+            'x-site-country': req.headers['x-site-country'],
+            'x-site-language': req.headers['x-site-language']
           }
         };
 

--- a/src/middleware/proxy.js
+++ b/src/middleware/proxy.js
@@ -186,6 +186,8 @@ module.exports = function backendProxyMiddleware(config, eventHandler, optionsTr
                 statsdTags: ['application:' + utils.getServiceNameFromUrl(layoutUrl)],
                 headers: {
                   'x-device': transformedOptions.headers['x-device'],
+                  'x-site-country': transformedOptions.headers['x-site-country'],
+                  'x-site-language': transformedOptions.headers['x-site-language'],
                   cookie: transformedOptions.headers.cookie
                 }
               }, handleErrorDecorator(function (err, response) {


### PR DESCRIPTION
This will pass `x-site-country` and `x-site-language` in to both a template and an html fragment.

See tes/resources#5032