### PR TITLE
Allow backend config to be an object, allows per env over-rides

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -78,8 +78,8 @@ function filterCookies(whitelist, cookies) {
   }, '');
 }
 
-function getBackendConfig(config, url, req) {
-  return _.find(config.backend, function (server) {
+function getBackendConfig(config, backends, url, req) {
+  return _.find(backends, function (server) {
     // Then try to match based on pattern in backend Config
     if (server.pattern) {
       return [].concat(server.pattern).some(function (pattern) {

--- a/test/acceptance/compoxure.keys.test.js
+++ b/test/acceptance/compoxure.keys.test.js
@@ -1,0 +1,136 @@
+'use strict';
+
+var expect = require('expect.js');
+var async = require('async');
+var request = require('request');
+var _ = require('lodash');
+var http = require('http');
+var cheerio = require('cheerio');
+var stubServer = require('../common/stubServer');
+var stubServer2 = require('../common/stubServer2');
+var pcServer = require('../common/pcServer');
+
+describe("Page Composer - Keyed Backend Config", function () {
+
+  var runningServers;
+
+  this.timeout(5000);
+  this.slow(3000);
+
+  before(function (done) {
+    async.series([
+      initStubServer,
+      initStubServer2,
+      initPageComposer
+    ], function(err, servers) {
+      runningServers = servers;
+      done();
+    });
+  });
+
+  after(function (done) {
+    async.map(runningServers, function(server, cb) {
+      server.close();
+      cb();
+    }, done);
+  });
+
+  function createEventHandler() {
+    return {
+      logger: function (level, message, data) {
+      },
+      stats: function (type, key, value) {
+      }
+    }
+  }
+
+  function initStubServer(next) {
+    stubServer.init('pageComposerTest.html', 5001, 'localhost')(next);
+  }
+
+  function initStubServer2(next) {
+    stubServer2.init('pageComposerTest.html', 6001, 'localhost')(next);
+  }
+
+  function initPageComposer(next) {
+    pcServer.init(5000, 'localhost', createEventHandler(), 'testConfigKeys')(next);
+  }
+
+  function getPageComposerUrl(path, search) {
+
+    var url = require('url').format({
+      protocol: 'http',
+      hostname: 'localhost',
+      port: 5000,
+      pathname: path,
+      search: search
+    });
+
+    return url;
+  }
+
+  it('should fail quietly if the backend is configured to do so', function (done) {
+    var requestUrl = getPageComposerUrl('quiet');
+    request.get(requestUrl, { headers: { 'accept': 'text/html' } }, function (err, response, content) {
+      var $ = cheerio.load(content);
+      expect($('#faulty').text()).to.be.equal('Faulty service');
+      done();
+    });
+  });
+
+  it('should fail loudly if the backend is configured to do so', function (done) {
+    var requestUrl = getPageComposerUrl();
+    request.get(requestUrl, { headers: { 'accept': 'text/html' } }, function (err, response, content) {
+      var $ = cheerio.load(content);
+      expect($('#faulty').text()).to.be.contain('status code 500');
+      done();
+    });
+  });
+
+  context('x-compoxure-backend headers', function() {
+
+    it('should use allow you to specify a server via x-compoxure-backend headers that has backend config as defaults', function (done) {
+      var requestUrl = getPageComposerUrl('');
+      request.get(requestUrl, { headers: { 'x-compoxure-backend': 'different', 'x-compoxure-backend-target': 'http://localhost:6001', 'accept': 'text/html' } }, function (err, response) {
+        expect(response.statusCode).to.be(200);
+        expect(response.headers['x-guid']).to.not.be(undefined);
+        expect(response.body).to.be('I am from the second stub server!');
+        done();
+      });
+    });
+
+    it('should use allow you to specify a server via x-compoxure-backend headers that doesnt have backend config', function (done) {
+      var requestUrl = getPageComposerUrl('');
+      request.get(requestUrl, { headers: { 'x-compoxure-backend-target': 'http://localhost:6001', 'accept': 'text/html' } }, function (err, response) {
+        expect(response.statusCode).to.be(200);
+        expect(response.headers['x-guid']).to.be(undefined);
+        expect(response.body).to.be('I am from the second stub server!');
+        done();
+      });
+    });
+
+  });
+
+  function getSection(path, search, query, next) {
+    var url = getPageComposerUrl(path, search);
+    request.get(url, { headers: { 'accept': 'text/html' } }, function (err, response, content) {
+      expect(err).to.be(null);
+      var $ = cheerio.load(content);
+      next($(query).text());
+    });
+  }
+
+  function getSectionAuth(query, userId, next) {
+    var j = request.jar();
+    var cookie = request.cookie('TSLCookie=' + userId);
+    j.setCookie(cookie, getPageComposerUrl());
+    request.get(getPageComposerUrl(), {
+      jar: j,
+      headers: { 'accept': 'text/html' }
+    }, function (err, response, content) {
+      expect(err).to.be(null);
+      var $ = cheerio.load(content);
+      next($(query).text());
+    });
+  }
+});

--- a/test/acceptance/compoxure.test.js
+++ b/test/acceptance/compoxure.test.js
@@ -12,6 +12,8 @@ var pcServer = require('../common/pcServer');
 
 describe("Page Composer", function () {
 
+  var runningServers;
+
   this.timeout(5000);
   this.slow(3000);
 
@@ -21,7 +23,17 @@ describe("Page Composer", function () {
       initStubServer2,
       initPageComposer,
       initPageComposerMinified
-    ], done);
+    ], function(err, servers) {
+      runningServers = servers;
+      done();
+    });
+  });
+
+  after(function (done) {
+    async.map(runningServers, function(server, cb) {
+      server.close();
+      cb();
+    }, done);
   });
 
   function createEventHandler() {

--- a/test/common/pcServer.js
+++ b/test/common/pcServer.js
@@ -53,20 +53,23 @@ function initPcServer(port, hostname, eventHandler, configFile, enableExtension)
 
   var compoxureMiddleware = cx(config, eventHandler, optionsTransformer);
 
-  var server = express();
+  var app = express();
 
-  server.use(cookieParser());
-  server.use(function (req, res, next) {
+  app.use(cookieParser());
+  app.use(function (req, res, next) {
     // This would be a call off to a service (e.g. planout based)
     // To retrieve active experiments for the current user.
     // Assumed it returns a simple object one level of properties deep
     req.experiments = { details_block: 'A123', another_test: 'B112' };
     next();
   });
-  server.use(compoxureMiddleware);
+  app.use(compoxureMiddleware);
 
   return function (next) {
-    server.listen(port, hostname).on('listening', next)
+    var server = app.listen(port);
+    server.on('listening', function() {
+      next(null, server);
+    });
   }
 
 }

--- a/test/common/stubServer.js
+++ b/test/common/stubServer.js
@@ -495,7 +495,10 @@ function initStubServer(fileName, port/*, hostname*/) {
   });
 
   return function (next) {
-    app.listen(port).on('listening', next);
+    var server = app.listen(port);
+    server.on('listening', function() {
+      next(null, server);
+    });
   };
 }
 

--- a/test/common/stubServer2.js
+++ b/test/common/stubServer2.js
@@ -21,7 +21,10 @@ function initStubServer(fileName, port/*, hostname*/) {
   });
 
   return function (next) {
-    app.listen(port).on('listening', next);
+    var server = app.listen(port)
+    server.on('listening', function() {
+      next(null, server);
+    });
   };
 }
 

--- a/test/common/testConfigKeys.json
+++ b/test/common/testConfigKeys.json
@@ -1,0 +1,228 @@
+{
+  "cdn": {
+    "url": "http://localhost:5001/static/"
+  },
+  "cookies": {
+    "whitelist": [
+      "CompoxureCookie",
+      "TSLCookie",
+      "siteCountry"
+    ]
+  },
+  "parameters": {
+    "urls": [
+      {
+        "pattern": "/pattern/.*-(\\d+)",
+        "names": [
+          "storyId"
+        ]
+      }
+    ],
+    "servers": {
+      "local": "http://localhost:5001",
+      "local-extension": "http://localhost:5011"
+    }
+  },
+  "content": {
+    "server": "http://localhost:5001/content"
+  },
+  "backend": {
+    "404backend": {
+      "pattern": "/404backend",
+      "target": "http://localhost:5001/404backend"
+    },
+    "418backend": {
+      "pattern": "/418backend",
+      "target": "http://localhost:5001/418backend"
+    },
+    "alternate500": {
+      "pattern": "/alternate500",
+      "quietFailure": true,
+      "ttl": 1,
+      "cacheKey": "cache:alternate500",
+      "target": "{{server:local}}/alternate500"
+    },
+    "nocachealternate500": {
+      "pattern": "/nocachekey-alternate500",
+      "quietFailure": true,
+      "ttl": 1,
+      "dontPassUrl": true,
+      "target": "{{server:local}}/alternate500"
+    },
+    "403": {
+      "pattern": "/403",
+      "target": "http://localhost:5001/403"
+    },
+    "302": {
+      "pattern": "/302",
+      "target": "http://localhost:5001/302"
+    },
+    "selectFnTest": {
+      "fn": "selectFnTest",
+      "target": "http://localhost:5001/selectFnBackend"
+    },
+    "quiet": {
+      "pattern": "/quiet.*",
+      "target": "http://localhost:5001",
+      "quietFailure": true
+    },
+    "leave": {
+      "pattern": "/leave.*",
+      "target": "http://localhost:5001",
+      "quietFailure": true,
+      "leaveContentOnFail": true
+    },
+    "post": {
+      "pattern": "/post.*",
+      "dontPassUrl": false,
+      "target": "http://localhost:5001",
+      "passThrough": true
+    },
+    "tracer": {
+      "pattern": "/tracer",
+      "target": "http://localhost:5001/tracer"
+    },
+    "header": {
+      "pattern": "/header",
+      "dontPassUrl": false,
+      "target": "http://localhost:5001",
+      "headers": [
+        "x-geoip-country-code"
+      ]
+    },
+    "differenthost": {
+      "pattern": "/differenthost",
+      "target": "http://localhost:5001/differenthost",
+      "host": "tes.co.uk"
+    },
+    "variabletarget": {
+      "pattern": "/variabletarget",
+      "target": "{{server:local}}"
+    },
+    "transformer": {
+      "name": "transformer",
+      "pattern": "/transformer",
+      "cacheKey": "cache-key",
+      "dontPassUrl": false,
+      "target": "{{server:local}}"
+    },
+    "additionalHeaders": {
+      "name": "additionalHeaders",
+      "pattern": "/additionalHeaders",
+      "cacheKey": "additional-headers",
+      "target": "{{server:local}}",
+      "dontPassUrl": false,
+      "addResponseHeaders": {
+        "x-robots-tag": "noindex"
+      }
+    },
+    "passThroughHeaders": {
+      "name": "passThroughHeaders",
+      "pattern": "/passThroughHeaders",
+      "cacheKey": "allow-headers",
+      "target": "{{server:local}}",
+      "dontPassUrl": false,
+      "passThroughHeaders": [
+        "x-robots-tag"
+      ]
+    },
+    "noCacheBackendViaFragment": {
+      "name": "noCacheBackendViaFragment",
+      "pattern": "/noCacheBackendViaFragment",
+      "target": "{{server:local}}",
+      "dontPassUrl": false,
+      "cacheKey": "noCacheBackendViaFragment",
+      "passThroughHeaders": [
+        "cache-control"
+      ]
+    },
+    "noCacheBackendNoHeader": {
+      "name": "noCacheBackendNoHeader",
+      "pattern": "/noCacheBackendNoHeader",
+      "dontPassUrl": false,
+      "target": "{{server:local}}"
+    },
+    "noCacheBackendWithHeader": {
+      "name": "noCacheBackendWithHeader",
+      "pattern": "/noCacheBackendWithHeader",
+      "dontPassUrl": false,
+      "target": "{{server:local}}",
+      "addResponseHeaders": {
+        "Cache-Control": "max-age=0"
+      }
+    },
+    "noCacheBackend": {
+      "name": "noCacheBackend",
+      "pattern": "/noCacheBackend",
+      "noCache": true,
+      "dontPassUrl": false,
+      "target": "{{server:local}}",
+      "passThroughHeaders": [
+        "cache-control"
+      ]
+    },
+    "noCacheBackendSetCookie": {
+      "name": "noCacheBackendSetCookie",
+      "pattern": "/set-cookie",
+      "noCache": true,
+      "dontPassUrl": false,
+      "target": "{{server:local}}",
+      "passThroughHeaders": [
+        "cache-control"
+      ]
+    },
+    "patternArray": {
+      "pattern": [
+        "/arrayOfPattern1",
+        "/arrayOfPattern2"
+      ],
+      "dontPassUrl": false,
+      "target": "{{server:local}}"
+    },
+    "browserExtension": {
+      "pattern": "/browser-extension",
+      "target": "http://localhost:5011/browser-extension-not-parsed"
+    },
+    "different": {
+      "name": "different",
+      "noCache": false,
+      "dontPassUrl": false,
+      "passThroughHeaders": [
+        "x-guid"
+      ]
+    },
+    "fallback": {
+      "pattern": ".*",
+      "dontPassUrl": false,
+      "target": "http://localhost:5001"
+    }
+  },
+  "circuitbreaker": {
+    "windowDuration": 10000,
+    "numBuckets": 10,
+    "errorThreshold": 100,
+    "volumeThreshold": 20
+  },
+  "statusCodeHandlers": {
+    "403": {
+      "fn": "handle403",
+      "data": {
+        "redirect": "http://www.google.com"
+      }
+    },
+    "302": {
+      "fn": "handle302"
+    },
+    "418": {
+      "fn": "handle418"
+    }
+  },
+  "cache": {
+    "defaultNoCacheHeaders": {
+      "cache-control": "private, no-cache, max-age=0, must-revalidate, no-store"
+    },
+    "engine": "memorycache"
+  },
+  "followRedirect": false,
+  "fragmentDepth": 3
+}


### PR DESCRIPTION
This allows the backend config block to be an object, where the key is equivalent to the `name` property that used to be in each array item.

This allows us to have per environment overrides (as you can merge objects, but not arrays in conflab).