### PR TITLE
fix: missing cdn configuration block should not crash the application

### DIFF
--- a/src/middleware/htmlparser.js
+++ b/src/middleware/htmlparser.js
@@ -32,13 +32,13 @@ function getNoCacheAttr(fragment) {
 
 function getMiddleware(config, reliableGet, eventHandler, optionsTransformer) {
   function getCdnHost() {
-    if (config.cdn.host) {
+    if (config.cdn && config.cdn.host) {
       return config.cdn.host;
     }
   }
 
   function getCdnUrl() {
-    if (config.cdn.url) {
+    if (config.cdn && config.cdn.url) {
       return config.cdn.url;
     }
   }


### PR DESCRIPTION
Starting with an configuration file without the 'cdn' key crashes the application with:

compoxture-composer_1      | /usr/src/app/node_modules/compoxure/src/middleware/htmlparser.js:35
compoxture-composer_1      |     if (config.cdn.host) {
compoxture-composer_1      |                    ^
compoxture-composer_1      |
compoxture-composer_1      | TypeError: Cannot read property 'host' of undefined
compoxture-composer_1      |     at getCdnHost (/usr/src/app/node_modules/compoxure/src/middleware/htmlparser.js:35:20)