### PR TITLE
Allow slots to be used by nested components

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,6 +360,20 @@ If there is more than one cx-use-slot with the same name, the content of all of 
 
 This can be useful if fragments from different services want to add the content in the same place.
 
+Note: By default only content assigned to a slot from the initial content request will be considered for loading into a slot.
+
+If you want to have nested fragments load content into the slots defined as part of the layout then you will need to have an additional header returned by your first content response.  In addition to the cx-layout and cx-parse-me headers you will need to assign the cx-allow-slot-use header.  For example:
+
+```
+{
+  'cx-layout': 'http://www.example.com/layout.html',
+  'cx-parse-me': 'true',
+  'cx-allow-slot-use': 'true',
+}
+```
+
+This configuration causes an additional parse of the initial content response to take place so has been added as an opt in option to keep the performance stable for exising applications.
+
 #### Nested Fragments
 
 Compoxure will parse fragments within fragments up to ```fragmentDepth``` deep. If not specified with default to 5. For this to remain performant, a service responding with a fragment containing compoxure directives will need also send a response header of ```cx-parse-me: true```.

--- a/src/middleware/htmlparser.js
+++ b/src/middleware/htmlparser.js
@@ -358,6 +358,18 @@ function getMiddleware(config, reliableGet, eventHandler, optionsTransformer) {
       parxer(getParxerOpts(1), data, parseCallback);
     };
 
+    // used to parse the content without returning it on the request
+    res.parseOnly = function parseOnly(data, pocb) {
+      parxer(getParxerOpts(1), data, function(err, fragmentIndex, content) {
+        // Overall errors
+        if (!res.headersSent && err.content) {
+          res.writeHead(err.statusCode || 500, { 'Content-Type': 'text/html' });
+          return res.end(err.content);
+        }
+
+        pocb(null, content);
+      });
+    }
     cb();
   };
 }

--- a/test/acceptance/compoxure.test.js
+++ b/test/acceptance/compoxure.test.js
@@ -1023,6 +1023,19 @@ describe("Page Composer", function () {
         done();
       });
     });
+
+    it('should handle sub requests using slots while leaving body in place', function (done) {
+      var requestUrl = getPageComposerUrl('cx-slot-sub-request-2');
+      request.get(requestUrl, { headers: { 'accept': 'text/html' } }, function (err, response, content) {
+        var expectedHTML = '<html>Header:<div>Foo1Bar1</div>Content:<div>Leave behind me</div>Footer:<div>Foo2Bar2</div></html>';
+        var $ = cheerio.load(response.body);
+        expect(response.body).to.be(expectedHTML);
+        expect($('div').slice(0, 1).text()).to.be('Foo1Bar1');
+        done();
+      });
+    });
+
+
   });
 
   function getSection(path, search, query, next) {

--- a/test/acceptance/compoxure.test.js
+++ b/test/acceptance/compoxure.test.js
@@ -981,6 +981,50 @@ describe("Page Composer", function () {
     });
   });
 
+  context('Slot handling', function () {
+    it('should process simple slot definitions', function (done) {
+      var requestUrl = getPageComposerUrl('cx-simple-slot-use');
+      request.get(requestUrl, { headers: { 'accept': 'text/html' } }, function (err, response, content) {
+        var expectedHTML = '<html>Slot1:<div>Slot1</div>Slot2:<div>For slot 2</div></html>';
+        var $ = cheerio.load(response.body);
+        expect(response.body).to.be(expectedHTML);
+        expect($('div').slice(0, 1).text()).to.be('Slot1');
+        done();
+      });
+    });
+
+    it('shouldn\'t handle slot use without the header', function (done) {
+      var requestUrl = getPageComposerUrl('cx-additional-slot-use');
+      request.get(requestUrl, { headers: { 'accept': 'text/html' } }, function (err, response, content) {
+        var $ = cheerio.load(response.body);
+        expect(response.body).to.be('<html>Slot1:<div>Slot1SLOT3</div>Slot2:<div>For slot 2</div></html>');
+        done();
+      });
+    });
+
+    it('should handle combining content into slots', function (done) {
+      var requestUrl = getPageComposerUrl('cx-double-slot-use');
+      request.get(requestUrl, { headers: { 'accept': 'text/html' } }, function (err, response, content) {
+        var expectedHTML = '<html>Slot1:<div>THISTHAT</div>Slot2:<div></div></html>';
+        var $ = cheerio.load(response.body);
+        expect(response.body).to.be(expectedHTML);
+        expect($('div').slice(0, 1).text()).to.be('THISTHAT');
+        done();
+      });
+    });
+
+    it('should handle sub requests using slots', function (done) {
+      var requestUrl = getPageComposerUrl('cx-slot-sub-request');
+      request.get(requestUrl, { headers: { 'accept': 'text/html' } }, function (err, response, content) {
+        var expectedHTML = '<html>Slot1:<div><p id="foo">Foo</p></div>Slot2:<div>Bar</div></html>';
+        var $ = cheerio.load(response.body);
+        expect(response.body).to.be(expectedHTML);
+        expect($('#foo').text()).to.be('Foo');
+        done();
+      });
+    });
+  });
+
   function getSection(path, search, query, next) {
     var url = getPageComposerUrl(path, search);
     request.get(url, { headers: { 'accept': 'text/html' } }, function (err, response, content) {

--- a/test/common/stubServer.js
+++ b/test/common/stubServer.js
@@ -532,6 +532,37 @@ function initStubServer(fileName, port/*, hostname*/) {
     res.end('<div><div cx-url-1="{{server:local}}/empty" cx-url-2="{{server:local}}/fragment-content-id?id=fragment-2" cx-url-3="{{server:local}}/fragment-content-id?id=fragment-3" cx-strategy="first-non-empty" class="container"></div></div>');
   });
 
+  app.get('/slot-layout', function (req, res) {
+    res.writeHead(200, { "Content-Type": "text/html" });
+    res.end('<html>Slot1:<div cx-define-slot="slot1"></div>Slot2:<div cx-define-slot="slot2"></div></html>');
+  });
+
+  app.get('/cx-simple-slot-use', function (req, res) {
+    res.writeHead(200, { "Content-Type": "text/html", "cx-parse-me": true, "cx-layout": "{{server:local}}/slot-layout" });
+    res.end('<html><div cx-use-slot="slot1">Slot1</div><div cx-use-slot="slot2">For slot 2</div></html>');
+  });
+
+  app.get('/cx-additional-slot-use', function (req, res) {
+    res.writeHead(200, { "Content-Type": "text/html", "cx-parse-me": true, "cx-layout": "{{server:local}}/slot-layout" });
+    res.end('<html><div cx-use-slot="slot1">Slot1<compoxure cx-define-slot="slot3"></div></div><div cx-use-slot="slot2">For slot 2</div><div cx-use-slot="slot3">SLOT3</div></html>');
+  });
+
+  app.get('/cx-double-slot-use', function (req, res) {
+    res.writeHead(200, { "Content-Type": "text/html", "cx-parse-me": true, "cx-layout": "{{server:local}}/slot-layout" });
+    res.end('<div cx-use-slot="slot1">THIS</div><div cx-use-slot="slot1">THAT</div>');
+  });
+
+  app.get('/cx-slot-sub-request', function (req, res) {
+    res.writeHead(200, { "Content-Type": "text/compoxure", "cx-parse-me": true, "cx-allow-slot-use": true, "cx-layout": "{{server:local}}/slot-layout"
+  });
+    res.end('<div cx-use-slot="slot1" cx-replace-outer="true"><p id="foo">Foo</p></div><div cx-url="{{server:local}}/cx-slot-sub-request-content" cx-replace-outer="true"></div>');
+  });
+
+  app.get('/cx-slot-sub-request-content', function (req, res) {
+    res.writeHead(200, { "Content-Type": "text/html", "cx-parse-me": true });
+    res.end('<div cx-use-slot="slot2" cx-replace-outer="true">Bar</div>');
+  });
+
   return function (next) {
     app.listen(port).on('listening', next);
   };

--- a/test/common/stubServer.js
+++ b/test/common/stubServer.js
@@ -537,6 +537,11 @@ function initStubServer(fileName, port/*, hostname*/) {
     res.end('<html>Slot1:<div cx-define-slot="slot1"></div>Slot2:<div cx-define-slot="slot2"></div></html>');
   });
 
+  app.get('/slot-layout-2', function (req, res) {
+    res.writeHead(200, { "Content-Type": "text/html" });
+    res.end('<html>Header:<div cx-define-slot="header"></div>Content:<div cx-define-slot="content"></div>Footer:<div cx-define-slot="footer"></div></html>');
+  });
+
   app.get('/cx-simple-slot-use', function (req, res) {
     res.writeHead(200, { "Content-Type": "text/html", "cx-parse-me": true, "cx-layout": "{{server:local}}/slot-layout" });
     res.end('<html><div cx-use-slot="slot1">Slot1</div><div cx-use-slot="slot2">For slot 2</div></html>');
@@ -562,6 +567,18 @@ function initStubServer(fileName, port/*, hostname*/) {
     res.writeHead(200, { "Content-Type": "text/html", "cx-parse-me": true });
     res.end('<div cx-use-slot="slot2" cx-replace-outer="true">Bar</div>');
   });
+
+  app.get('/cx-slot-sub-request-2', function (req, res) {
+    res.writeHead(200, { "Content-Type": "text/compoxure", "cx-parse-me": true, "cx-allow-slot-use": true, "cx-layout": "{{server:local}}/slot-layout-2"
+  });
+    res.end('<div cx-use-slot="header" cx-replace-outer="true">Foo1</div><div cx-use-slot="footer">Foo2</div><div cx-use-slot="content"><div cx-url="{{server:local}}/cx-slot-sub-request-content-2" cx-replace-outer="true"></div></div>');
+  });
+
+  app.get('/cx-slot-sub-request-content-2', function (req, res) {
+    res.writeHead(200, { "Content-Type": "text/html", "cx-parse-me": true });
+    res.end('<div cx-use-slot="header" cx-replace-outer="true">Bar1</div><div cx-use-slot="footer" cx-replace-outer="true">Bar2</div>Leave behind me');
+  });
+
 
   return function (next) {
     app.listen(port).on('listening', next);

--- a/test/unit/extract-slots.test.js
+++ b/test/unit/extract-slots.test.js
@@ -59,4 +59,18 @@ describe('extractSlot', function () {
         done();
       });
     });
+
+    it('extracts nested slots', function (done) {
+      var s = '<div cx-use-slot="header" cx-replace-outer="true">Foo1</div><div cx-use-slot="footer">Foo2</div><div cx-use-slot="content"><span cx-use-slot="header" cx-replace-outer="true">Bar1</span><span cx-use-slot="footer" cx-replace-outer="true">Bar2</span>Leave behind me</div>';
+      extractSlots(s, function (err, slots) {
+        expect(slots).to.eql({
+          header: 'Foo1Bar1',
+          footer: 'Foo2Bar2',
+          content: 'Leave behind me',
+        });
+        done();
+      });
+    });
+
+    //
 });


### PR DESCRIPTION
The intention of this PR is to implement changes to the nested fragments to allow Drupal to define things which get put into the layout template slots.  In order to get some JS working on the pageas we are updating in the school portal we need to have the Drupal CSS appear in the header of the document and some of the js appear in the footer.  Currently only things from the initial request which define the layout are allowed to assign things to the slots.  Which is a pain.

What we are wanting to achieve in is something like this:

School portal returns a fragment which has a layout associated with it.
School portal assigns content to the head and footer-scripts using the cx-use-slot attribute.
In the fragment somewhere we have a div with a cx-url that points to drupal with something like
```
<div cx-parse-me cx-url="{{server:drupal}}:/somemagicurl"></div>
```

Drupal will return some content fragment which looks like this:
```
<div use-slot="head">
 . . . some css stuff
</div>
<div use-slot="footer-scripts">
 . . . some js script stuff
</div>
<div>
   . . . . . The content that we want to embed
</div>
```

As the current compoxure doesn't do anything with blocks and nested fragments this PR fixes that.

I have made the behaviour opt in so as to not break any of the current pages and also made it obvious in the README that this behaviour doesn't happen be default. 